### PR TITLE
Fix Azure OpenAI validation

### DIFF
--- a/src/settings/components/ApiSettings.tsx
+++ b/src/settings/components/ApiSettings.tsx
@@ -40,6 +40,15 @@ const ApiSettings: React.FC = () => {
     setAzureDeployments(settings.azureOpenAIApiDeployments || []);
   }, [settings.azureOpenAIApiDeployments]);
 
+  const validateAzureDeployment = (deployment: AzureOpenAIDeployment): boolean => {
+    return (
+      deployment.deploymentName.trim() !== "" &&
+      deployment.instanceName.trim() !== "" &&
+      deployment.apiKey.trim() !== "" &&
+      deployment.apiVersion.trim() !== ""
+    );
+  };
+
   const handleAddAzureDeployment = () => {
     const newDeployment = {
       deploymentName: defaultAzureDeployment.deploymentName,
@@ -47,6 +56,12 @@ const ApiSettings: React.FC = () => {
       apiKey: defaultAzureDeployment.apiKey,
       apiVersion: defaultAzureDeployment.apiVersion,
     };
+
+    if (!validateAzureDeployment(newDeployment)) {
+      alert("Please fill in all fields for the Azure deployment.");
+      return;
+    }
+
     const updatedDeployments = [...azureDeployments, newDeployment];
     setAzureDeployments(updatedDeployments);
     updateSetting("azureOpenAIApiDeployments", updatedDeployments);
@@ -61,6 +76,11 @@ const ApiSettings: React.FC = () => {
   };
 
   const handleUpdateAzureDeployment = (index: number, updatedDeployment: AzureOpenAIDeployment) => {
+    if (!validateAzureDeployment(updatedDeployment)) {
+      alert("Please fill in all fields for the Azure deployment.");
+      return;
+    }
+
     const updatedDeployments = [...azureDeployments];
     updatedDeployments[index] = updatedDeployment;
     setAzureDeployments(updatedDeployments);


### PR DESCRIPTION
Add validation logic for Azure OpenAI API keys in `ApiSettings.tsx`.

* **Validation Function**
  - Add `validateAzureDeployment` function to check if all fields in the Azure deployment are filled.

* **Add Deployment Validation**
  - Update `handleAddAzureDeployment` to validate the new deployment before adding it.
  - Show an alert if the new deployment is not valid.

* **Update Deployment Validation**
  - Update `handleUpdateAzureDeployment` to validate the updated deployment before saving it.
  - Show an alert if the updated deployment is not valid.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/henryperkins/obsidian-copilot/pull/2?shareId=2989220c-2676-47db-bb3b-51eeb0254865).